### PR TITLE
Fix: register controls 3.5.0 deprecated warning

### DIFF
--- a/core/Plugin.php
+++ b/core/Plugin.php
@@ -103,7 +103,7 @@ class Plugin extends Singleton {
 
 		new Ajax();
 
-		add_action( 'elementor/controls/controls_registered', [ new Controls(), 'on_controls_registered' ] );
+		add_action( 'elementor/controls/register', [ new Controls(), 'on_controls_registered' ] );
 		require_once STAX_VISIBILITY_CORE_PATH . 'helpers/modules/QueryControl.php';
 
 		add_action( 'elementor/editor/before_enqueue_scripts', [ $this, 'before_load_panel_assets' ] );

--- a/core/helpers/Controls.php
+++ b/core/helpers/Controls.php
@@ -69,9 +69,9 @@ class Controls {
 	public function register_controls() {
 		$controls_manager = \Elementor\Plugin::$instance->controls_manager;
 
-		foreach ( $this->controls as $key => $name ) {
+		foreach ( $this->controls as $name ) {
 			$class = self::$namespace . $name;
-			$controls_manager->register_control( $key, new $class() );
+			$controls_manager->register( new $class() );
 		}
 	}
 


### PR DESCRIPTION
Error message

```php
Deprecated
: The $control_id argument is deprecated since version 3.5.0! in
/..../..../wp-content/plugins/elementor/modules/dev-tools/deprecation.php
on line
316
```

Visibility Logic Elementor – 2.3.2 (current latest version)
Elementor – Version 3.10.1
Elementor Pro – Version 3.10.2


Reference Issue : https://wordpress.org/support/topic/the-control_id-argument-is-deprecated-since-version-3-5-0-4/

