### PR TITLE
v2.4.0: WP 6.9 + Elementor 3.35 compatibility, PHP 8.x fixes, UI impr…

### DIFF
--- a/assets/css/panel.css
+++ b/assets/css/panel.css
@@ -41,29 +41,14 @@
   border-radius: 30px;
 }
 
-.stax-status-active .elementor-panel-heading-title:after,
-.stax-status-inactive .elementor-panel-heading-title:after,
-.stax-status-error .elementor-panel-heading-title:after {
+.stax-status-active .elementor-panel-heading-title:after {
   font-family: eicons;
+  content: "\e90d";
   position: absolute;
   right: 0;
   z-index: 2;
   font-size: 16px;
-}
-
-.stax-status-active .elementor-panel-heading-title:after {
-  content: "\e90d";
   color: #229b12;
-}
-
-.stax-status-inactive .elementor-panel-heading-title:after {
-  content: "\e93a";
-  color: #797979;
-}
-
-.stax-status-error .elementor-panel-heading-title:after {
-  content: "\e946";
-  color: #e32525;
 }
 
 .elementor-control-old_version_note .elementor-control-content {

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -131,6 +131,7 @@ var STAXVisibilityEditor = STAXVisibilityEditor || {};
     },
 
     initStateDisplay: function () {
+      // Update state on switcher toggle and section click
       $(document).on(
         "click",
         ".elementor-control-type-switcher .elementor-switch, .elementor-panel-heading",
@@ -140,6 +141,13 @@ var STAXVisibilityEditor = STAXVisibilityEditor || {};
           }, 100);
         }
       );
+
+      // Update state when element is selected in the panel
+      elementor.channels.editor.on("section:activated", function () {
+        setTimeout(function () {
+          STAXVisibilityEditor.fn.checkState();
+        }, 100);
+      });
 
     },
 
@@ -159,13 +167,7 @@ var STAXVisibilityEditor = STAXVisibilityEditor || {};
           ) {
             item.status = "active";
           } else {
-            item.status = "inactive";
-          }
-
-          if (
-            currentElement.$el.hasClass("stax-" + item.name + "_enabled-error")
-          ) {
-            item.status = "error";
+            item.status = "";
           }
         });
 
@@ -173,22 +175,20 @@ var STAXVisibilityEditor = STAXVisibilityEditor || {};
           index,
           item
         ) {
-          $(item)
-            .removeClass("stax-status-active")
-            .removeClass("stax-status-inactive")
-            .removeClass("stax-status-error");
+          $(item).removeClass("stax-status-active");
 
           let _this = $(item);
 
           $.each(options, function (i, optionItem) {
             if (
+              optionItem.status === "active" &&
               _this.hasClass(
                 "elementor-control-stax_visibility_" +
                   optionItem.name +
                   "_section"
               )
             ) {
-              _this.addClass("stax-status-" + optionItem.status);
+              _this.addClass("stax-status-active");
             }
           });
         });
@@ -202,11 +202,21 @@ var STAXVisibilityEditor = STAXVisibilityEditor || {};
     STAXVisibilityEditor.fn.initSelect2();
     STAXVisibilityEditor.fn.initStateDisplay();
 
-      // Hook into Elementor's panel events
-    elementor.on('panel:init', function () {
+    // Check state when any element panel opens
+    elementor.hooks.addAction('panel/open_editor/widget', function () {
       setTimeout(function () {
         STAXVisibilityEditor.fn.checkState();
-      }, 1000);
+      }, 200);
+    });
+    elementor.hooks.addAction('panel/open_editor/section', function () {
+      setTimeout(function () {
+        STAXVisibilityEditor.fn.checkState();
+      }, 200);
+    });
+    elementor.hooks.addAction('panel/open_editor/container', function () {
+      setTimeout(function () {
+        STAXVisibilityEditor.fn.checkState();
+      }, 200);
     });
   });
 

--- a/conditional.php
+++ b/conditional.php
@@ -5,10 +5,10 @@
  * Plugin URI: https://wordpress.org/plugins/visibility-logic-elementor
  * Author URI: https://staxwp.com
  * Author: StaxWP
- * Version: 2.3.9
+ * Version: 2.4.0
  *
- * Elementor tested up to: 3.25.5
- * Elementor Pro tested up to: 3.25.5
+ * Elementor tested up to: 3.35
+ * Elementor Pro tested up to: 3.35
  *
  * Text Domain: visibility-logic-elementor
  */
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit; // Exit if accessed directly.
 }
 
-define( 'STAX_VISIBILITY_VERSION', '2.3.9' );
+define( 'STAX_VISIBILITY_VERSION', '2.4.0' );
 
 define( 'STAX_VISIBILITY_FILE', __FILE__ );
 define( 'STAX_VISIBILITY_PLUGIN_BASE', plugin_basename( STAX_VISIBILITY_FILE ) );

--- a/core/Plugin.php
+++ b/core/Plugin.php
@@ -71,7 +71,7 @@ class Plugin extends Singleton {
 
 		add_action( 'wp_footer', [ $this, 'editor_show_visibility_icon' ] );
 
-		$this->load_settings();
+		add_action( 'init', [ $this, 'load_settings' ], 0 );
 
 		do_action( 'stax/visibility/after_init' );
 	}

--- a/core/helpers/Resources.php
+++ b/core/helpers/Resources.php
@@ -215,34 +215,45 @@ final class Resources extends Singleton {
 	 * @return string
 	 */
 	public static function get_browser_type() {
-		global $is_lynx, $is_gecko, $is_IE, $is_opera, $is_NS4, $is_safari, $is_chrome, $is_iphone, $is_android;
-
-		$android = stripos( $_SERVER['HTTP_USER_AGENT'], 'Android' );
-
-		if ( $is_lynx ) {
-			return 'is_lynx';
-		} elseif ( $is_gecko ) {
-			return 'is_gecko';
-		} elseif ( $is_opera ) {
-			return 'is_opera';
-		} elseif ( $is_NS4 ) {
-			return 'is_ns4';
-		} elseif ( $is_safari ) {
-			return 'is_safari';
-		} elseif ( $is_chrome ) {
-			return 'is_chrome';
-		} elseif ( $is_IE ) {
-			return 'is_ie';
-		} else {
+		if ( ! isset( $_SERVER['HTTP_USER_AGENT'] ) ) {
 			return 'is_unknown';
 		}
 
-		if ( $is_iphone ) {
-			return 'is_ios';
+		$ua = $_SERVER['HTTP_USER_AGENT'];
+
+		// Check Edge first (contains Chrome/Safari in UA string)
+		if ( stripos( $ua, 'Edge' ) !== false || stripos( $ua, 'Edg/' ) !== false ) {
+			return 'is_edge';
 		}
 
-		if ( $android ) {
+		global $is_lynx, $is_gecko, $is_IE, $is_opera, $is_NS4, $is_safari, $is_chrome, $is_iphone;
+
+		if ( $is_iphone ) {
+			return 'is_iphone';
+		}
+		if ( stripos( $ua, 'Android' ) !== false ) {
 			return 'is_android';
+		}
+		if ( $is_chrome ) {
+			return 'is_chrome';
+		}
+		if ( $is_safari ) {
+			return 'is_safari';
+		}
+		if ( $is_gecko ) {
+			return 'is_gecko';
+		}
+		if ( $is_opera ) {
+			return 'is_opera';
+		}
+		if ( $is_IE ) {
+			return 'is_ie';
+		}
+		if ( $is_lynx ) {
+			return 'is_lynx';
+		}
+		if ( $is_NS4 ) {
+			return 'is_ns4';
 		}
 
 		return 'is_unknown';

--- a/core/settings/BrowserTypeVisiblity.php
+++ b/core/settings/BrowserTypeVisiblity.php
@@ -93,6 +93,7 @@ class BrowserTypeVisiblity extends Singleton {
 					'is_opera'  => 'Opera',
 					'is_lynx'   => 'Lynx',
 					'is_iphone' => 'iPhone Safari',
+					'is_android' => 'Android Browser',
 				],
 				'description'    => __( 'Trigger visibility for specific browsers.', 'visibility-logic-elementor' ),
 				'multiple'       => true,

--- a/core/settings/DateTimeVisibility.php
+++ b/core/settings/DateTimeVisibility.php
@@ -197,7 +197,7 @@ class DateTimeVisibility extends Singleton {
 			[
 				'type'           => Controls_Manager::RAW_HTML,
 				'raw'            => __( 'Use timestamps based on server time:', 'visibility-logic-elementor' ) .
-									 '<br><strong>' . date( 'Y-m-d H:i', current_time( 'timestamp' ) ) . '</strong>',
+									 '<br><strong>' . wp_date( 'Y-m-d H:i' ) . '</strong>',
 				'condition'      => [
 					self::SECTION_PREFIX . 'date_time_enabled' => 'yes',
 				],
@@ -229,7 +229,7 @@ class DateTimeVisibility extends Singleton {
 			case 'date':
 				$date_from    = $settings[ self::SECTION_PREFIX . 'date_from' ];
 				$date_to      = $settings[ self::SECTION_PREFIX . 'date_to' ];
-				$current_date = current_time( 'timestamp' );
+				$current_date = current_datetime()->getTimestamp();
 
 				if ( $date_from && $date_to ) {
 					if ( $current_date >= strtotime( $date_from ) && $current_date <= strtotime( $date_to ) ) {

--- a/core/settings/UserMetaVisibility.php
+++ b/core/settings/UserMetaVisibility.php
@@ -274,12 +274,12 @@ class UserMetaVisibility extends Singleton {
 					}
 					break;
 				case 'contain':
-					if ( strpos( $user_meta, $meta_check_value ) === false ) {
+					if ( ! is_string( $user_meta ) || strpos( $user_meta, $meta_check_value ) === false ) {
 						$meta_is_consistent = false;
 					}
 					break;
 				case 'not_contain':
-					if ( strpos( $user_meta, $meta_check_value ) !== false ) {
+					if ( is_string( $user_meta ) && strpos( $user_meta, $meta_check_value ) !== false ) {
 						$meta_is_consistent = false;
 					}
 					break;
@@ -320,6 +320,7 @@ class UserMetaVisibility extends Singleton {
 				case 'is_array_and_contains':
 					if ( ! is_array( $user_meta ) ) {
 						$meta_is_consistent = false;
+						break;
 					}
 
 					$values = explode( ',', $meta_check_value );

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: staxwp, kierantaylorio, codezz, rtynio, geowrge
 Tags: elementor, elementor restrictions, elementor conditions, elementor widgets, widget conditions
 Requires at least: 5.0
-Requires PHP: 7.0
-Tested up to: 6.7
-Stable tag: 2.3.9
+Requires PHP: 7.4
+Tested up to: 6.9
+Stable tag: 2.4.0
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -79,6 +79,16 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 6. Visibility Logic for Elementor - Admin Panel
 
 == Changelog ==
+
+= 2.4.0 =
+* WordPress 6.9 compatibility
+* Elementor 3.35 compatibility
+* Fix: Replace deprecated current_time('timestamp') with current_datetime()
+* Fix: Browser detection now properly detects Edge, iPhone and Android browsers
+* Fix: PHP 8.x warnings for undefined HTTP_USER_AGENT
+* Fix: PHP 8.x TypeError when using strpos() on non-string user meta values
+* Fix: Early translation loading notice on WordPress 6.7+
+* Improved: Minimum PHP version raised to 7.4
 
 = 2.3.9 =
 * Fix compatibility with Elementor 3.12.0


### PR DESCRIPTION
Improvements. 
- WordPress 6.9 and Elementor 3.35 compatibility
- Fix deprecated current_time('timestamp') with current_datetime()
- Fix browser detection: Edge, iPhone, Android support + isset check
- Fix PHP 8.x TypeError on strpos/array_intersect in UserMeta conditions
- Fix early translation loading notice on WP 6.7+
- Visibility status icons: show only active (green check), update on panel open
- Minimum PHP raised to 7.4